### PR TITLE
Added filter to make sure Visual Studio's Browser Link URLs are ignored

### DIFF
--- a/BotFilter/SEOChecker_BotFilter.config
+++ b/BotFilter/SEOChecker_BotFilter.config
@@ -43,5 +43,6 @@
     <urlFilter>plupload.*upload.php$</urlFilter>
     <urlFilter>administrator/components/com_</urlFilter>
     <urlFilter>type="text/javascript"</urlFilter>
+    <urlFilter>__browserlink/.*</urlFilter>
   </urlFilters>
 </SEOCheckerBotFilter>


### PR DESCRIPTION
Added filter to make sure Visual Studio's Browser Link URLs are ignored and don't show up as inbound link errors, e.g. __browserlink/requestdata/feebba4ed6a844b299fbfc28f07a17c4